### PR TITLE
Build debug-agent image from distroless  static image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:3.4
-RUN apk add --update --no-cache ca-certificates && rm /var/cache/apk/*
+FROM gcr.io/distroless/static
 
 COPY ./debug-agent /bin/debug-agent
 EXPOSE 10027


### PR DESCRIPTION
Hi aylei, this pr might be the solution for https://github.com/aylei/kubectl-debug/issues/19.  I've tested it in my cluster, distoless image prevents user executing shell in the agent container, just like this:
```
root@iZhp37kmiszbkwzt5oh9csZ:~/k/kube-debug# kubectl get pod
NAME                    READY   STATUS    RESTARTS   AGE
debug-agent-t8sgd       1/1     Running   0          17m
debug-agent-wfvp4       1/1     Running   0          17m
hhhh-5f88b9f6bc-qrwrm   1/1     Running   0          3d
nginx                   1/1     Running   0          3d2h
root@iZhp37kmiszbkwzt5oh9csZ:~/k/kube-debug# kubectl exec -it debug-agent-t8sgd sh
OCI runtime exec failed: exec failed: container_linux.go:345: starting container process caused "exec: \"sh\": executable file not found in $PATH": unknown
command terminated with exit code 126

```