### PR TITLE
Add agentless mode to debug target pod when there isn't an agent running on target host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:3.4
-RUN apk add --update --no-cache ca-certificates && rm /var/cache/apk/*
+FROM gcr.io/distroless/static
 
 COPY ./debug-agent /bin/debug-agent
 EXPOSE 10027

--- a/pkg/plugin/cmd.go
+++ b/pkg/plugin/cmd.go
@@ -202,7 +202,7 @@ func NewDebugCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		"Debug agent daemonset name when using port-forward")
 	cmd.Flags().StringVar(&opts.DebugAgentNamespace, "daemonset-ns", opts.DebugAgentNamespace,
 		"Debug agent namespace, default to 'default'")
-	// falgs used for agentless mode.
+	// flags used for agentless mode.
 	cmd.Flags().BoolVar(&opts.AgentLess, "agent-less", false, "Whether to turn on agentless mode. Agentless mode: debug target pod if there isn't an agent running on the target host.")
 	cmd.Flags().StringVar(&opts.AgentImage, "agent-image", "",
 		fmt.Sprintf("Agentless mode, the container Image to run the agent container , default to %s", defaultAgentImage))

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -13,6 +13,9 @@ type Config struct {
 	DebugAgentNamespace string   `yaml:"debugAgentNamespace,omitempty"`
 	Command             []string `yaml:"command,omitempty"`
 	PortForward         bool     `yaml:"portForward,omitempty"`
+	AgentPodNamePrefix  string   `yaml:"agentPodNamePrefix,omitempty"`
+	AgentPodNamespace   string   `yaml:"agentPodNamespace,omitempty"`
+	AgentImage          string   `yaml:"agentImage,omitempty"`
 
 	// deprecated
 	AgentPortOld int `yaml:"agent_port,omitempty"`

--- a/scripts/agent_daemonset.yml
+++ b/scripts/agent_daemonset.yml
@@ -35,7 +35,7 @@ spec:
         volumeMounts:
         - name: docker
           mountPath: "/var/run/docker.sock"
-      hostNetwork: true
+      # hostNetwork: true
       volumes:
       - name: docker
         hostPath:


### PR DESCRIPTION

Hi aylei, this PR adds agentless mode to debug target container when there isn't agent pod running on the targetHost. In agentless mode, we don't need to deploy agent daemonset any more. 

In this mode, we first start agent pod on target node, and then start debugging container. Both agent pod and debug container will be deleted when debug process exists.The size of debug-agent image is about 30MB, so the preparation time for starting agent pod might not be too long when the network is OK. 

I've tested some cases without agent daemonset deployed:
- agentless mode when port-forward mode is on
```
root@iZhp37kmiszbkwzt5oh9csZ:/kq# ./kubectl-debug nginx  --agent-less=true  --port-foward=true
Agent Pod info : 
	Name:debug-agent-pod-izhp3gki207s34o84d5nluz
	Namespace:default
	HostPort:10027

2019/05/18 13:01:21 waiting for container running...
pod nginx PodIP 10.42.1.2, agentPodIP 10.10.251.242
wait for forward port to debug agent ready...
Forwarding from 127.0.0.1:10027 -> 10027
Handling connection for 10027
                             pulling image nicolaka/netshoot:latest... 
latest: Pulling from nicolaka/netshoot
Digest: sha256:5b1f5d66c4fa48a931ff54f2f34e5771eff2bc5e615fef441d5858e30e9bb921
Status: Image is up to date for nicolaka/netshoot:latest
starting debug container...
container created, open tty...
bash-5.0# 


```
- agentless mode when port-forward mode is off
```
root@iZhp37kmiszbkwzt5oh9csZ:/kq# ./kubectl-debug nginx  --agent-less=true 
Agent Pod info : 
	Name:debug-agent-pod-izhp3gki207s34o84d5nluz
	Namespace:default
	HostPort:10027

2019/05/18 13:00:44 waiting for container running...
pulling image nicolaka/netshoot:latest... 
latest: Pulling from nicolaka/netshoot
Digest: sha256:5b1f5d66c4fa48a931ff54f2f34e5771eff2bc5e615fef441d5858e30e9bb921
Status: Image is up to date for nicolaka/netshoot:latest
starting debug container...
container created, open tty...
bash-5.0#
```
- agentless mode when fork mode is on
```
root@iZhp37kmiszbkwzt5oh9csZ:/kq# ./kubectl-debug nginx  --agent-less=true  --port-foward=true --fork=true
Agent Pod info : 
	Name:debug-agent-pod-izhp3gki207s34o84d5nluz
	Namespace:default
	HostPort:10027

2019/05/18 13:02:29 waiting for container running...
2019/05/18 13:02:35 waiting for container running...
pod nginx PodIP 10.42.1.48, agentPodIP 10.10.251.242
wait for forward port to debug agent ready...
Forwarding from 127.0.0.1:10027 -> 10027
Handling connection for 10027
                             pulling image nicolaka/netshoot:latest... 
latest: Pulling from nicolaka/netshoot
Digest: sha256:5b1f5d66c4fa48a931ff54f2f34e5771eff2bc5e615fef441d5858e30e9bb921
Status: Image is up to date for nicolaka/netshoot:latest
starting debug container...
container created, open tty...
bash-5.0# 

```

In agentless mode ,it also supports changing agent port dynamically when port-forward mode is off, just like this：
```
root@iZhp37kmiszbkwzt5oh9csZ:/kq# ./kubectl-debug nginx  --agent-less=true  --fork=true --port=10000
Agent Pod info : 
	Name:debug-agent-pod-izhp3gki207s34o84d5nluz
	Namespace:default
	HostPort:10000

2019/05/18 13:05:12 waiting for container running...
2019/05/18 13:05:19 waiting for container running...
pulling image nicolaka/netshoot:latest... 
latest: Pulling from nicolaka/netshoot
Digest: sha256:5b1f5d66c4fa48a931ff54f2f34e5771eff2bc5e615fef441d5858e30e9bb921
Status: Image is up to date for nicolaka/netshoot:latest
starting debug container...
container created, open tty...
bash-5.0# 
```

In port-forward mode, it doesn't support changing agent port dynamically, just like this:
```
root@iZhp37kmiszbkwzt5oh9csZ:/kq# ./kubectl-debug nginx  --agent-less=true  --port-foward=true --fork=true --port=10000
Agent Pod info : 
	Name:debug-agent-pod-izhp3gki207s34o84d5nluz
	Namespace:default
	HostPort:10000

2019/05/18 13:11:17 waiting for container running...
2019/05/18 13:11:23 waiting for container running...
pod nginx PodIP 10.42.1.52, agentPodIP 10.10.251.242
wait for forward port to debug agent ready...
Forwarding from 127.0.0.1:10000 -> 10000  
Handling connection for 10000
                             E0518 13:11:25.953111    3607 portforward.go:391] an error occurred forwarding 10000 -> 10000: error forwarding port 10000 to pod 7ca26882144aea50595d148212f1f4929b934bbb58ef0a8419d1eba73763c4ff, uid : exit status 1: 2019/05/18 05:11:25 socat[3991] E connect(5, AF=2 127.0.0.1:10000, 16): Connection refused
                                                                                                         delete forked pod.....
                                                                                                                               delete agent pod.....
                                                                                                                                                    end port-forward...
                                                                                                                                                                       error execute remote, error sending request: Post http://localhost:10000/api/v1/debug?command=%5B%22bash%22%5D&container=docker%3A%2F%2F9fec37c64da810b42c1c069e9e850ce06e8ddc37f582e43e5c89116007183ff1&image=nicolaka%2Fnetshoot%3Alatest: unexpected EOF
error: error sending request: Post http://localhost:10000/api/v1/debug?command=%5B%22bash%22%5D&container=docker%3A%2F%2F9fec37c64da810b42c1c069e9e850ce06e8ddc37f582e43e5c89116007183ff1&image=nicolaka%2Fnetshoot%3Alatest: unexpected EOF
root@iZhp37kmiszbkwzt5oh9csZ:/kq# 

```
Agent pod listens on port 10027(inside container) and on port 10000(outside container), so `kubectl-debug` fails to connect pod's port 10000(inside container).  In the future, we can fix this by adding some parameter to config agent listening port and config agent-pod yaml respectively. :)