### PR TITLE
FIX:issue52, if a pod is running but not ready,we can connect to it

### DIFF
--- a/pkg/plugin/cmd.go
+++ b/pkg/plugin/cmd.go
@@ -488,8 +488,9 @@ func (o *DebugOptions) getContainerIDByName(pod *corev1.Pod, containerName strin
 		if containerStatus.Name != containerName {
 			continue
 		}
-		if !containerStatus.Ready {
-			return "", fmt.Errorf("container [%s] not ready", containerName)
+		// #52 if a pod is running but not ready(because of readiness probe), we can connect
+		if containerStatus.State.Running == nil {
+			return "", fmt.Errorf("container [%s] not running", containerName)
 		}
 		return containerStatus.ContainerID, nil
 	}


### PR DESCRIPTION
FIX:[issue52](https://github.com/aylei/kubectl-debug/issues/52), if a pod is running but not ready(about readiness probe), we can connect

like the initcontainner, if a pod is Running but not ready(because of the readiless Probe), we can connect to it.