### PR TITLE
FIX:issue58, k8s v1.16 daemonSet apiVersion change to apps/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,20 @@
 
 `kubectl-debug` is an out-of-tree solution for [troubleshooting running pods](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/troubleshoot-running-pods.md), which allows you to run a new container in running pods for debugging purpose ([examples](/docs/examples.md)). The new container will join the `pid`, `network`, `user` and `ipc` namespaces of the target container, so you can use arbitrary trouble-shooting tools without pre-installing them in your production container image.
 
-- [screenshots](#screenshots)
-- [quick start](#quick-start)
-- [build from source](#build-from-source)
-- [port-forward and agentless](#port-forward-mode-And-agentless-mode)
-- [configuration](#configuration)
-- [roadmap](#roadmap)
-- [authorization](#authorization)
-- [contribute](#contribute)
+- [Kubectl-debug](#kubectl-debug)
+- [Overview](#overview)
+- [Screenshots](#screenshots)
+- [Quick Start](#quick-start)
+  - [Install the kubectl debug plugin](#install-the-kubectl-debug-plugin)
+  - [(Optional) Install the debug agent DaemonSet](#optional-install-the-debug-agent-daemonset)
+  - [Debug instructions](#debug-instructions)
+- [Build from source](#build-from-source)
+- [port-forward mode And agentless mode](#port-forward-mode-and-agentless-mode)
+- [Configuration](#configuration)
+- [Authorization](#authorization)
+- [Roadmap](#roadmap)
+- [Contribute](#contribute)
+- [Acknowledgement](#acknowledgement)
 
 # Screenshots
 
@@ -54,9 +60,14 @@ For windows users, download the latest archive from the [release page](https://g
 While convenient, creating pod before debugging can be time consuming. You can install the debug agent DaemonSet in advance to skip this:
 
 ```bash
+# if your kubernetes version is v1.16 or newer
 kubectl apply -f https://raw.githubusercontent.com/aylei/kubectl-debug/master/scripts/agent_daemonset.yml
+# if your kubernetes is old version(<v1.16), you should change the apiVersion to extensions/v1beta1, As follows
+wget https://raw.githubusercontent.com/aylei/kubectl-debug/master/scripts/agent_daemonset.yml
+sed -i '' '1s/apps\/v1/extensions\/v1beta1/g' agent_daemonset.yml
+kubectl apply -f agent_daemonset.yml
 # or using helm
-helm install -n=debug-agent ./contrib/helm/kubectl-debug
+helm install kubectl-debug -n=debug-agent ./contrib/helm/kubectl-debug
 ```
 
 ## Debug instructions

--- a/contrib/helm/kubectl-debug/templates/agent-ds.yaml
+++ b/contrib/helm/kubectl-debug/templates/agent-ds.yaml
@@ -1,4 +1,8 @@
+{{- if ge .Capabilities.KubeVersion.Minor "16" }}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: DaemonSet
 metadata:
   name: {{ template "kubectl-debug.fullname" . }}-agent

--- a/docs/zh-cn.md
+++ b/docs/zh-cn.md
@@ -58,9 +58,14 @@ Windows 用户可以从 [release page](https://github.com/aylei/kubectl-debug/re
 `agentless` 虽然方便, 但会让 debug 的启动速度显著下降, 你可以通过预先安装 debug-agent 的 DaemonSet 来使用 agent 模式, 加快启动速度:
 
 ```bash
+# 如果你的kubernetes版本为v1.16或更高
 kubectl apply -f https://raw.githubusercontent.com/aylei/kubectl-debug/master/scripts/agent_daemonset.yml
-# 或者使用 helm 安装
-helm install -n=debug-agent ./contrib/helm/kubectl-debug
+# 如果你使用的是旧版本的kubernetes(<v1.16), 你需要先将apiVersion修改为extensions/v1beta1, 可以如下操作
+wget https://raw.githubusercontent.com/aylei/kubectl-debug/master/scripts/agent_daemonset.yml
+sed -i '' '1s/apps\/v1/extensions\/v1beta1/g' agent_daemonset.yml
+kubectl apply -f agent_daemonset.yml
+# 或者使用helm安装
+helm install kubectl-debug -n=debug-agent ./contrib/helm/kubectl-debug
 ```
 
 简单使用:

--- a/scripts/agent_daemonset.yml
+++ b/scripts/agent_daemonset.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:


### PR DESCRIPTION
fix [issue58](https://github.com/aylei/kubectl-debug/issues/58)

in k8s v1.16 , the daemonSet apiVersion change to apps/v1
fixed the helm chart and the scriptyaml
test in kubernetes v1.16.0