### PR TITLE
remove redundant os.Exit()

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"flag"
-	"github.com/aylei/kubectl-debug/pkg/agent"
 	"log"
-	"os"
+
+	"github.com/aylei/kubectl-debug/pkg/agent"
 )
 
 func main() {
@@ -16,18 +16,15 @@ func main() {
 	config, err := agent.LoadFile(configFile)
 	if err != nil {
 		log.Fatalf("error reading config %v", err)
-		os.Exit(1)
 	}
 
 	server, err := agent.NewServer(config)
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 
 	if err := server.Run(); err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 
 	log.Println("sever stopped, see you next time!")


### PR DESCRIPTION
`os.Exit(1)` is already called inside `log.Fatal`