### PR TITLE
FIX:issue45, in Fork && AgentLess mode, we'll delete the agentPod if Fork pod error

### DIFF
--- a/pkg/plugin/cmd.go
+++ b/pkg/plugin/cmd.go
@@ -345,6 +345,7 @@ func (o *DebugOptions) Run() error {
 		agentPod = o.getAgentPod()
 		agentPod, err = o.launchPod(agentPod)
 		if err != nil {
+			fmt.Fprintf(o.Out, "the agentPod is not running, you should check the reason and delete the failed agentPod and retry.\n")
 			return err
 		}
 	}
@@ -356,6 +357,8 @@ func (o *DebugOptions) Run() error {
 		pod = copyAndStripPod(pod, containerName)
 		pod, err = o.launchPod(pod)
 		if err != nil {
+			fmt.Fprintf(o.Out, "the ForkedPod is not running, you should check the reason and delete the failed ForkedPod and retry\n")
+			o.deleteAgent(agentPod)
 			return err
 		}
 	}


### PR DESCRIPTION
`1.one situation`
if we work in Fork && AgentLess mode, we need to delete the agentPod if Fork pod error.

`2.others situation`
i think if fork a target pod error, we shouldn't delete the completed/failed target forked pod. and retain the completed/failed target forked pod to let user looking for reasons.

same in agentPod create.

so we also add a error message for Fork Pod error and create AgentPod error. user should looking for error reason and delete the completed/failed pod(target forked pod or AgentPod) by themselves.


**This problem may affect the following issue**
[issue#40](https://github.com/aylei/kubectl-debug/issues/40)
[issue#45](https://github.com/aylei/kubectl-debug/issues/45)