### PR TITLE
CHANGE:issue#44 Agentless and port-forward by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   - [(Optional) Install the debug agent DaemonSet](#optional-install-the-debug-agent-daemonset)
   - [Debug instructions](#debug-instructions)
 - [Build from source](#build-from-source)
-- [port-forward mode And agentless mode](#port-forward-mode-and-agentless-mode)
+- [port-forward mode And agentless mode(Default opening)](#port-forward-mode-and-agentless-modedefault-opening)
 - [Configuration](#configuration)
 - [Authorization](#authorization)
 - [Roadmap](#roadmap)
@@ -55,9 +55,9 @@ For windows users, download the latest archive from the [release page](https://g
 
 ## (Optional) Install the debug agent DaemonSet
 
-`kubectl-debug` requires an agent pod to communicate with the container runtime. In the [agentless mode](#port-forward-mode-And-agentless-mode), the agent pod can be created when a debug session starts and to be cleaned up when the session ends.
+`kubectl-debug` requires an agent pod to communicate with the container runtime. In the [agentless mode](#port-forward-mode-And-agentless-mode), the agent pod can be created when a debug session starts and to be cleaned up when the session ends.(Turn on agentless mode by default)
 
-While convenient, creating pod before debugging can be time consuming. You can install the debug agent DaemonSet in advance to skip this:
+While convenient, creating pod before debugging can be time consuming. You can install the debug agent DaemonSet and use --agentless=false params in advance to skip this:
 
 ```bash
 # if your kubernetes version is v1.16 or newer
@@ -68,6 +68,8 @@ sed -i '' '1s/apps\/v1/extensions\/v1beta1/g' agent_daemonset.yml
 kubectl apply -f agent_daemonset.yml
 # or using helm
 helm install kubectl-debug -n=debug-agent ./contrib/helm/kubectl-debug
+# use daemonset agent mode(close agentless mode)
+kubectl debug --agentless=false POD_NAME
 ```
 
 ## Debug instructions
@@ -77,16 +79,17 @@ Try it out!
 ```bash
 # kubectl 1.12.0 or higher
 kubectl debug -h
-# you can omit --agentless to reduce start time if you have installed the debug agent daemonset
-# we will omit this flag in the following commands
-kubectl debug POD_NAME --agentless
+# if you installed the debug agent's daemonset, you can use --agentless=false to speed up the startup.
+# the default agentless mode will be used in following commands
+kubectl debug POD_NAME
 
 # in case of your pod stuck in `CrashLoopBackoff` state and cannot be connected to,
 # you can fork a new pod and diagnose the problem in the forked pod
 kubectl debug POD_NAME --fork
 
-# if the node ip is not directly accessible, try port-forward mode
-kubectl debug POD_NAME --port-forward --daemonset-ns=kube-system --daemonset-name=debug-agent
+# in order to enable node without public IP or direct access (firewall and other reasons) to access, port-forward mode is enabled by default.
+# if you don't need to turn on port-forward mode, you can use --port-forward false to turn off it.
+kubectl debug POD_NAME --port-forward=false --agentless=false --daemonset-ns=kube-system --daemonset-name=debug-agent
 
 # old versions of kubectl cannot discover plugins, you may execute the binary directly
 kubectl-debug POD_NAME
@@ -125,11 +128,11 @@ make plugin
 make agent-docker
 ```
 
-# port-forward mode And agentless mode
+# port-forward mode And agentless mode(Default opening)
 
 - `port-foward` mode: By default, `kubectl-debug` will directly connect with the target host. When `kubectl-debug` cannot connect to `targetHost:agentPort`, you can enable `port-forward` mode. In `port-forward` mode, the local machine listens on `localhost:agentPort` and forwards data to/from `targetPod:agentPort`.
 
-- `agentless` mode: By default, `debug-agent` needs to be pre-deployed on each node of the cluster, which consumes cluster resources all the time. Unfortunately, debugging Pod is a low-frequency operation. To avoid loss of cluster resources, the `agentless` mode has been added in [#31](https://github.com/aylei/kubectl-debug/pull/31). In `agentless` mode, `kubectl-debug` will first start `debug-agent` on the host where the target Pod is located, and then `debug-agent`  starts the debug container. After the user exits, `kubectl-debug` will delete the debug container and `kubectl-debug` will delete the `debug-agent` pod  at last.
+- `agentless` mode: By default, `debug-agent` needs to be pre-deployed on each node of the cluster, which consumes cluster resources all the time. Unfortunately, debugging Pod is a low-frequency operation. To avoid loss of cluster resources, the `agentless` mode has been added in [#31](https://github.com/aylei/kubectl-debug/pull/31). In `agentless` mode, `kubectl-debug` will first start `debug-agent` on the host where the target Pod is located, and then `debug-agent`  starts the debug container. After the user exits, `kubectl-debug` will delete the debug container and `kubectl-debug` will delete the `debug-agent` pod at last.
 
 # Configuration
 
@@ -143,7 +146,7 @@ You can override the default image and entrypoint with cli flag, or even better,
 agentPort: 10027
 
 # whether using agentless mode
-# default to false
+# default to true
 agentless: true
 # namespace of debug-agent pod, used in agentless mode
 # default to 'default'
@@ -162,7 +165,7 @@ debugAgentDaemonset: debug-agent
 # default to 'default'
 debugAgentNamespace: kube-system
 # whether using port-forward when connecting debug-agent
-# default false
+# default true
 portForward: true
 # image of the debug container
 # default as showed

--- a/docs/zh-cn.md
+++ b/docs/zh-cn.md
@@ -53,9 +53,9 @@ Windows 用户可以从 [release page](https://github.com/aylei/kubectl-debug/re
 
 ## (可选) 安装 debug-agent DaemonSet   
 
-`kubectl-debug` 包含两部分, 一部分是用户侧的 kubectl 插件, 另一部分是部署在所有 k8s 节点上的 agent(用于启动"新容器", 同时也作为 SPDY 连接的中继). 在 `agentless` 中, `kubectl-debug` 会在 debug 开始时创建 debug-agent Pod, 并在结束后自动清理.
+`kubectl-debug` 包含两部分, 一部分是用户侧的 kubectl 插件, 另一部分是部署在所有 k8s 节点上的 agent(用于启动"新容器", 同时也作为 SPDY 连接的中继). 在 `agentless` 中, `kubectl-debug` 会在 debug 开始时创建 debug-agent Pod, 并在结束后自动清理.(默认开启agentless模式)
 
-`agentless` 虽然方便, 但会让 debug 的启动速度显著下降, 你可以通过预先安装 debug-agent 的 DaemonSet 来使用 agent 模式, 加快启动速度:
+`agentless` 虽然方便, 但会让 debug 的启动速度显著下降, 你可以通过预先安装 debug-agent 的 DaemonSet 并配合 --agentless=false 参数来使用 agent 模式, 加快启动速度:
 
 ```bash
 # 如果你的kubernetes版本为v1.16或更高
@@ -66,21 +66,24 @@ sed -i '' '1s/apps\/v1/extensions\/v1beta1/g' agent_daemonset.yml
 kubectl apply -f agent_daemonset.yml
 # 或者使用helm安装
 helm install kubectl-debug -n=debug-agent ./contrib/helm/kubectl-debug
+# 使用daemonset agent模式(关闭agentless模式)
+kubectl debug --agentless=false POD_NAME
 ```
 
 简单使用:
 ```bash
 # kubectl 1.12.0 或更高的版本, 可以直接使用:
 kubectl debug -h
-# 假如安装了 debug-agent 的 daemonset, 可以略去 --agentless 来加快启动速度
-# 之后的命令里会略去 --agentless
-kubectl debug POD_NAME --agentless
+# 假如安装了 debug-agent 的 daemonset, 可以使用 --agentless=false 来加快启动速度
+# 之后的命令里会使用默认的agentless模式
+kubectl debug POD_NAME
 
 # 假如 Pod 处于 CrashLookBackoff 状态无法连接, 可以复制一个完全相同的 Pod 来进行诊断
 kubectl debug POD_NAME --fork
 
-# 假如 Node 没有公网 IP 或无法直接访问(防火墙等原因), 请使用 port-forward 模式
-kubectl debug POD_NAME --port-forward --daemonset-ns=kube-system --daemonset-name=debug-agent
+# 为了使 没有公网 IP 或无法直接访问(防火墙等原因)的 NODE 能够访问, 默认开启 port-forward 模式
+# 如果不需要开启port-forward模式, 可以使用 --port-forward=false 来关闭
+kubectl debug POD_NAME --port-forward=false --agentless=false --daemonset-ns=kube-system --daemonset-name=debug-agent
 
 # 老版本的 kubectl 无法自动发现插件, 需要直接调用 binary
 kubectl-debug POD_NAME
@@ -116,11 +119,11 @@ make plugin
 make agent-docker
 ```
 
-# port-forward 模式和 agentless 模式
+# port-forward 模式和 agentless 模式(默认开启)
 
 - `port-foward`模式：默认情况下，`kubectl-debug`会直接与目标宿主机建立连接。当`kubectl-debug`无法与目标宿主机直连时，可以开启`port-forward`模式。`port-forward`模式下，本机会监听localhost:agentPort，并将数据转发至目标Pod的agentPort端口。
 
-- `agentless`模式： 默认情况下，`debug-agent`需要预先部署在集群每个节点上，会一直消耗集群资源，然而调试 Pod 是低频操作。为避免集群资源损失，在[#31](https://github.com/aylei/kubectl-debug/pull/31)增加了`agentless`模式。`agentless`模式下，`kubectl-debug`会先在目标Pod所在宿主机上启动`debug-agent`，然后再启动调试容器。用户调试结束后，`kubectl-debug`会依次删除调试容器和在目的主机启动的`degbug-agent`。
+- `agentless`模式： 默认情况下，`debug-agent`需要预先部署在集群每个节点上，会一直消耗集群资源，然而调试 Pod 是低频操作。为避免集群资源损失，在[#31](https://github.com/aylei/kubectl-debug/pull/31)增加了`agentless`模式。`agentless`模式下，`kubectl-debug`会先在目标Pod所在宿主机上启动`debug-agent`，然后再启动调试容器。用户调试结束后，`kubectl-debug`会依次删除调试容器和在目的主机启动的`debug-agent`。
 
 
 # 配置
@@ -133,7 +136,7 @@ make agent-docker
 agentPort: 10027
 
 # 是否开启ageless模式
-# 默认 false
+# 默认 true
 agentless: true
 # agentPod 的 namespace, agentless模式可用
 # 默认 default
@@ -152,7 +155,7 @@ debugAgentDaemonset: debug-agent
 # 默认 'default'
 debugAgentNamespace: kube-system
 # 是否开启 port-forward 模式
-# 默认 false
+# 默认 true
 portForward: true
 # image of the debug container
 # default as showed

--- a/pkg/plugin/cmd.go
+++ b/pkg/plugin/cmd.go
@@ -77,6 +77,9 @@ You may set default configuration such as image and command in the config file, 
 
 	defaultRegistrySecretName      = "kubectl-debug-registry-secret"
 	defaultRegistrySecretNamespace = "default"
+
+	defaultPortForward = true
+	defaultAgentless   = true
 )
 
 // DebugOptions specify how to run debug container in a running pod
@@ -172,14 +175,15 @@ func NewDebugCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		fmt.Sprintf("Debug config file, default to ~%s", defaultConfigLocation))
 	cmd.Flags().BoolVar(&opts.Fork, "fork", false,
 		"Fork a new pod for debugging (useful if the pod status is CrashLoopBackoff)")
-	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", false,
-		"Whether using port-forward to connect debug-agent")
+	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", true,
+		fmt.Sprintf("Whether using port-forward to connect debug-agent, default to %t", defaultPortForward))
 	cmd.Flags().StringVar(&opts.DebugAgentDaemonSet, "daemonset-name", opts.DebugAgentDaemonSet,
 		"Debug agent daemonset name when using port-forward")
 	cmd.Flags().StringVar(&opts.DebugAgentNamespace, "daemonset-ns", opts.DebugAgentNamespace,
 		"Debug agent namespace, default to 'default'")
 	// flags used for agentless mode.
-	cmd.Flags().BoolVarP(&opts.AgentLess, "agentless", "a", false, "Whether to turn on agentless mode. Agentless mode: debug target pod if there isn't an agent running on the target host.")
+	cmd.Flags().BoolVarP(&opts.AgentLess, "agentless", "a", true,
+		fmt.Sprintf("Whether to turn on agentless mode. Agentless mode: debug target pod if there isn't an agent running on the target host, default to %t", defaultAgentless))
 	cmd.Flags().StringVar(&opts.AgentImage, "agent-image", "",
 		fmt.Sprintf("Agentless mode, the container Image to run the agent container , default to %s", defaultAgentImage))
 	cmd.Flags().StringVar(&opts.AgentPodName, "agent-pod-name-prefix", "",


### PR DESCRIPTION
issue #44 
change the mode to agentless and port-forward default.
if user want to close agentless or port-forward mode, should use 
`--agentless=false --port-forward=false`