### PR TITLE
Misc enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Currently, `kubectl-debug` reuse the privilege of the `pod/exec` sub resource to
 
 Some teams may want to limit what debug image users are allowed to use and to have an audit record for each command they run in the debug container.
 
-You can use the environent variable ```KCTLDBG_RESTRICT_IMAGE_TO``` restrict the agent to using a specific container image.   For example putting the following in the container spec section of your daemonset yaml will force the agent to always use the image ```docker.io/nicolaka/netshoot:latest``` regardless of what the user specifies on the kubectl-debug command line 
+You can use the environment variable ```KCTLDBG_RESTRICT_IMAGE_TO``` restrict the agent to using a specific container image.   For example putting the following in the container spec section of your daemonset yaml will force the agent to always use the image ```docker.io/nicolaka/netshoot:latest``` regardless of what the user specifies on the kubectl-debug command line 
 ```
           env : 
             - name: KCTLDBG_RESTRICT_IMAGE_TO

--- a/go.sum
+++ b/go.sum
@@ -368,6 +368,7 @@ k8s.io/apiserver v0.0.0-20181220070914-ce7b605bead3 h1:GIl6hq5bRA5OSLauW8qCPfibG
 k8s.io/apiserver v0.0.0-20181220070914-ce7b605bead3/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
 k8s.io/cli-runtime v0.0.0-20190228180923-a9e421a79326 h1:uMY/EHQt0VHYgRMPWwPl/vQ0K0fPlt5zxTEGAdt8pDg=
 k8s.io/cli-runtime v0.0.0-20190228180923-a9e421a79326/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
+k8s.io/cli-runtime v0.18.2 h1:JiTN5RgkFNTiMxHBRyrl6n26yKWAuNRlei1ZJALUmC8=
 k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4 h1:aE8wOCKuoRs2aU0OP/Rz8SXiAB0FTTku3VtGhhrkSmc=
 k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,7 @@ k8s.io/apiserver v0.0.0-20181220070914-ce7b605bead3/go.mod h1:6bqaTSOSJavUIXUtfa
 k8s.io/cli-runtime v0.0.0-20190228180923-a9e421a79326 h1:uMY/EHQt0VHYgRMPWwPl/vQ0K0fPlt5zxTEGAdt8pDg=
 k8s.io/cli-runtime v0.0.0-20190228180923-a9e421a79326/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/cli-runtime v0.18.2 h1:JiTN5RgkFNTiMxHBRyrl6n26yKWAuNRlei1ZJALUmC8=
+k8s.io/cli-runtime v0.18.3 h1:8IBtaTYmXiXipKdx2FAKotvnQMjcF0kSLvX4szY340c=
 k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4 h1:aE8wOCKuoRs2aU0OP/Rz8SXiAB0FTTku3VtGhhrkSmc=
 k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=
@@ -380,6 +381,7 @@ k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580/go.mod h1:BXM9ceUBTj2QnfH
 k8s.io/kubernetes v1.13.1 h1:IwCCcPOZwY9rKcQyBJYXAE4Wgma4oOW5NYR3HXKFfZ8=
 k8s.io/kubernetes v1.13.1/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.18.1 h1:qW6zgSY96X/NO+ueIIfsFSbHl/e0Txio62XcA4cxpIk=
+k8s.io/kubernetes v1.18.2 h1:37sJPq6p+gx5hEHQSwCWXIiXDc9AajzV1A5UrswnDq0=
 k8s.io/utils v0.0.0-20181115163542-0d26856f57b3 h1:S3/Kq185JnolOEemhmDXXd23l2t4bX5hPQPQPADlF1E=
 k8s.io/utils v0.0.0-20181115163542-0d26856f57b3/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/pkg/plugin/cmd.go
+++ b/pkg/plugin/cmd.go
@@ -524,6 +524,9 @@ func (o *DebugOptions) Run() error {
 		var agent *corev1.Pod
 		if !o.AgentLess {
 			// Agent is running
+			if o.Verbosity > 0 {
+				o.Logger.Printf("Fetching daemonset '%v' from namespace %v\r\n", o.DebugAgentDaemonSet, o.DebugAgentNamespace)
+			}
 			daemonSet, err := o.KubeCli.AppsV1().DaemonSets(o.DebugAgentNamespace).Get(o.DebugAgentDaemonSet, v1.GetOptions{})
 			if err != nil {
 				return err

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -37,6 +37,9 @@ type Config struct {
 
 func Load(s string) (*Config, error) {
 	cfg := &Config{}
+	cfg.Agentless = true
+	cfg.PortForward = true
+	cfg.IsLxcfsEnabled = true
 	err := yaml.Unmarshal([]byte(s), cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -6,10 +6,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type RegistryAuthConfig struct {
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
-}
 type Config struct {
 	AgentPort               int      `yaml:"agentPort,omitempty"`
 	Image                   string   `yaml:"image,omitempty"`

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -20,4 +20,4 @@ then
   export KCTLDBG_CONTAINERDV1_SHIM=io.containerd.runc.v1
 fi   
 
-/bin/debug-agent
+/bin/debug-agent "$@"


### PR DESCRIPTION
- Add support for pulling debug image from IBM Cloud Repository.   In IBM Cloud the secrets are stored in a JSON  blob instead of the key value pair authStr:<secret>.   So if we don't find an 'authStr' value we look for the JSON blob.

- Add additional logging around registry authentication + fix grammar in a log message.

- For boolean switches ( e.g. port-forward ) that had a default value of true it wasn't possible to specify a value of false in the config file.  Because of a logic bug kubectl-debug would ignore the value from the config file in this case.

- kubectl-debug couldn't find the config file on Windows because it was using the wrong path separator.