### PR TITLE
agent pod pull secret

### DIFF
--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -11,26 +11,28 @@ type RegistryAuthConfig struct {
 	Password string `yaml:"password,omitempty"`
 }
 type Config struct {
-	AgentPort               int      `yaml:"agentPort,omitempty"`
-	Image                   string   `yaml:"image,omitempty"`
-	RegistrySecretName      string   `yaml:"registrySecretName,omitempty"`
-	RegistrySecretNamespace string   `yaml:"registrySecretNamespace,omitempty"`
-	RegistrySkipTLSVerify   bool     `yaml:"registrySkipTLSVerify,omitempty"`
-	ForkPodRetainLabels     []string `yaml:"forkPodRetainLabels,omitempty"`
-	DebugAgentDaemonSet     string   `yaml:"debugAgentDaemonset,omitempty"`
-	DebugAgentNamespace     string   `yaml:"debugAgentNamespace,omitempty"`
-	Command                 []string `yaml:"command,omitempty"`
-	PortForward             bool     `yaml:"portForward,omitempty"`
-	Agentless               bool     `yaml:"agentless,omitempty"`
-	AgentPodNamePrefix      string   `yaml:"agentPodNamePrefix,omitempty"`
-	AgentPodNamespace       string   `yaml:"agentPodNamespace,omitempty"`
-	AgentImage              string   `yaml:"agentImage,omitempty"`
-	AgentPodCpuRequests     string   `yaml:"agentCpuRequests,omitempty"`
-	AgentPodMemoryRequests  string   `yaml:"agentMemoryRequests,omitempty"`
-	AgentPodCpuLimits       string   `yaml:"agentCpuLimits,omitempty"`
-	AgentPodMemoryLimits    string   `yaml:"agentMemoryLimits,omitempty"`
-	IsLxcfsEnabled          bool     `yaml:"isLxcfsEnabled,omitempty"`
-	Verbosity               int      `yaml:"verbosity,omitempty"`
+	AgentPort                int      `yaml:"agentPort,omitempty"`
+	Image                    string   `yaml:"image,omitempty"`
+	RegistrySecretName       string   `yaml:"registrySecretName,omitempty"`
+	RegistrySecretNamespace  string   `yaml:"registrySecretNamespace,omitempty"`
+	RegistrySkipTLSVerify    bool     `yaml:"registrySkipTLSVerify,omitempty"`
+	ForkPodRetainLabels      []string `yaml:"forkPodRetainLabels,omitempty"`
+	DebugAgentDaemonSet      string   `yaml:"debugAgentDaemonset,omitempty"`
+	DebugAgentNamespace      string   `yaml:"debugAgentNamespace,omitempty"`
+	Command                  []string `yaml:"command,omitempty"`
+	PortForward              bool     `yaml:"portForward,omitempty"`
+	Agentless                bool     `yaml:"agentless,omitempty"`
+	AgentPodNamePrefix       string   `yaml:"agentPodNamePrefix,omitempty"`
+	AgentPodNamespace        string   `yaml:"agentPodNamespace,omitempty"`
+	AgentImage               string   `yaml:"agentImage,omitempty"`
+	AgentImagePullPolicy     string   `yaml:"agentImagePullPolicy,omitempty"`
+	AgentImagePullSecretName string   `yaml:"agentImagePullSecretName,omitempty"`
+	AgentPodCpuRequests      string   `yaml:"agentCpuRequests,omitempty"`
+	AgentPodMemoryRequests   string   `yaml:"agentMemoryRequests,omitempty"`
+	AgentPodCpuLimits        string   `yaml:"agentCpuLimits,omitempty"`
+	AgentPodMemoryLimits     string   `yaml:"agentMemoryLimits,omitempty"`
+	IsLxcfsEnabled           bool     `yaml:"isLxcfsEnabled,omitempty"`
+	Verbosity                int      `yaml:"verbosity,omitempty"`
 	// deprecated
 	AgentPortOld int `yaml:"agent_port,omitempty"`
 }


### PR DESCRIPTION
1. Add a param AgentImagePullPolicy(agent-pull-policy in command line) for agentless mode, default value: PullIfNotPresent.
2. Add a param AgentImagePullSecretName(agent-pull-secret-name in command line) for agentless mode, default empty.

This may useful when pulling agent image from private registry, 
such as: #109 , #89 